### PR TITLE
Add a custom range helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please, Ember 1.13+ only. Sorry. :(
 Also, if you want to view the examples, clone this repository, `ember server` and visit `localhost:4200` (example app is in `/tests/dummy/app/`).
 
 ## Example
-Here's an example of a scatterplot where the x position of the circle represents the year, the y position represents the temerature, and the size of the circle represents the rainfall.
+Here's an example of a scatterplot where the x position of the circle represents the year, the y position represents the temperature, and the size of the circle represents the rainfall.
 
 ```javascript
 // index/route.js
@@ -50,20 +50,21 @@ export default Ember.Route.extend({
 ```handlebars
 // index/template.hbs
 {{#e3-container type='canvas' height=400 width=800 as |context meta|}}
-  <meta>
+  <metadata>
     {{e3-scale/linear context 'x'
-      domain=(e3-extent model key='year')
+      domain=(e3-extent model key='year' padding=0.2)
       range=context.horizontalRange
     }}
     {{e3-scale/linear context 'y'
-      domain=(e3-extent model key='temperature')
+      domain=(e3-extent model key='temperature' padding=0.2)
       range=context.verticalRange
+      invert=true
     }}
-    {{e3-scale/linear context 'r'
+    {{e3-scale/linear context 'radius'
       domain=(e3-extent model key='rainfall')
-      range=context.verticalRange
+      range=(e3-fixed-range min=5 max=20)
     }}
-  </meta>
+  </metadata>
   {{#each model as |item|}}
     {{e3-shape/circle context
       data=item

--- a/addon/helpers/e3-fixed-range.js
+++ b/addon/helpers/e3-fixed-range.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export function e3FixedRange(params, hash) {
+  var min = hash['min'] || 0;
+  var max = hash['max'] || 100;
+  return [min, max];
+}
+
+export default Ember.Helper.helper(e3FixedRange);

--- a/app/helpers/e3-fixed-range.js
+++ b/app/helpers/e3-fixed-range.js
@@ -1,0 +1,1 @@
+export { default, e3FixedRange } from 'ember-e3/helpers/e3-fixed-range';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-e3",
-  "version": "0.0.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "0.0.2",
+  "description": "Data visualization the Ember way",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
   this.route('text-sample');
   this.route('bar-chart');
   this.route('grouped-bars');
+  this.route('invert');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/invert.js
+++ b/tests/dummy/app/routes/invert.js
@@ -1,0 +1,47 @@
+import Ember from 'ember';
+export default Ember.Route.extend({
+  model() {
+    return [
+        {
+          year: 2010,
+          rainfall: 41,
+          temperature: 96
+        },
+        {
+          year: 2011,
+          rainfall: 35,
+          temperature: 95
+        },
+        {
+          year: 2012,
+          rainfall: 33,
+          temperature: 96
+        },
+        {
+          year: 2013,
+          rainfall: 32,
+          temperature: 91
+        },
+        {
+          year: 2014,
+          rainfall: 27,
+          temperature: 89
+        },
+        {
+          year: 2015,
+          rainfall: 26,
+          temperature: 85
+        },
+        {
+          year: 2016,
+          rainfall: 20,
+          temperature: 81
+        },
+        {
+          year: 2017,
+          rainfall: 16,
+          temperature: 74
+        }
+    ];
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,7 +2,7 @@
 
 <p>
   {{link-to 'Bar Chart' 'bar-chart'}}
-  {{link-to 'Circles' 'stacked-bar'}}
+  {{link-to 'Circles' 'bubble-1'}}
   {{link-to 'Line graph' 'line-graph'}}
   {{link-to 'Smoothed line graph' 'smooth-line-graph'}}
   {{link-to 'Stacked bars' 'stacked-bar'}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -8,6 +8,7 @@
   {{link-to 'Stacked bars' 'stacked-bar'}}
   {{link-to 'Grouped Bars' 'grouped-bars'}}
   {{link-to 'Text' 'text-sample'}}
+  {{link-to 'Inverted axis' 'invert'}}
 </p>
 
 {{outlet}}

--- a/tests/dummy/app/templates/invert.hbs
+++ b/tests/dummy/app/templates/invert.hbs
@@ -1,0 +1,55 @@
+<h3>Canvas</h3>
+{{#e3-container type='canvas' height=400 width=800 as |context meta|}}
+  <metadata>
+    {{e3-scale/linear context 'x'
+      domain=(e3-extent model key='year' padding=0.2)
+      range=context.horizontalRange
+    }}
+    {{e3-scale/linear context 'y'
+      domain=(e3-extent model key='temperature' padding=0.2)
+      range=context.verticalRange
+      invert=true
+    }}
+    {{e3-scale/linear context 'radius'
+      domain=(e3-extent model key='rainfall')
+      range=(e3-fixed-range min=5 max=20)
+    }}
+  </metadata>
+  {{#each model as |item|}}
+    {{e3-shape/circle context
+      data=item
+      x=(e3-bind-scale meta.scales.x 'year')
+      y=(e3-bind-scale meta.scales.y 'temperature')
+      radius=(e3-bind-scale meta.scales.radius 'rainfall')
+      fill='#afc726'
+    }}
+  {{/each}}
+{{/e3-container}}
+
+<h3>SVG</h3>
+{{#e3-container type='svg' height=400 width=800 as |context meta|}}
+  <metadata>
+    {{e3-scale/linear context 'x'
+      domain=(e3-extent model key='year' padding=0.2)
+      range=context.horizontalRange
+    }}
+    {{e3-scale/linear context 'y'
+      domain=(e3-extent model key='temperature' padding=0.2)
+      range=context.verticalRange
+      invert=true
+    }}
+    {{e3-scale/linear context 'radius'
+      domain=(e3-extent model key='rainfall')
+      range=(e3-fixed-range min=5 max=20)
+    }}
+  </metadata>
+  {{#each model as |item|}}
+    {{e3-shape/circle context
+      data=item
+      x=(e3-bind-scale meta.scales.x 'year')
+      y=(e3-bind-scale meta.scales.y 'temperature')
+      radius=(e3-bind-scale meta.scales.radius 'rainfall')
+      fill='#afc726'
+    }}
+  {{/each}}
+{{/e3-container}}

--- a/tests/unit/helpers/e3-fixed-range-test.js
+++ b/tests/unit/helpers/e3-fixed-range-test.js
@@ -1,0 +1,13 @@
+import { e3FixedRange } from '../../../helpers/e3-fixed-range';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | e3 fixed range');
+
+test('returns the range fom min to max', function(assert) {
+  var result = e3FixedRange([], {min: 1, max: 2});
+  assert.deepEqual(result, [1, 2]);
+});
+
+test('it does not explode without params', function(assert) {
+  assert.ok(e3FixedRange([], {}));
+});


### PR DESCRIPTION
It's all well and good mapping your range to the dimensions of the canvas but what if you're working
over some set outputs, e.g. the radius of a circle?

Implements a helper for this purpose `range=(e3-fixed-range min=5 max=20)`.

Not explicitly documented but does add an example to the `README.md`.