### PR TITLE
Upgrade package dependencies to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+[![npm version](https://badge.fury.io/js/ember-e3@2x.png)](http://badge.fury.io/js/ember-e3)
 [![Build Status](https://travis-ci.org/RavelLaw/e3.svg?branch=master)](https://travis-ci.org/RavelLaw/e3)
+[![Code Climate](https://codeclimate.com/github/RavelLaw/e3/badges/gpa.svg)](https://codeclimate.com/github/RavelLaw/e3)
 
 # E3
 

--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,14 @@
 {
   "name": "ember-e3",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "1.13.9",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-cli-test-loader": "0.2.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
+    "ember-qunit": "0.4.10",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
+    "loader.js": "3.3.0",
     "qunit": "~1.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-e3",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Data visualization the Ember way",
   "directories": {
     "doc": "doc",
@@ -20,21 +20,21 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.5.0",
+    "ember-cli-app-version": "1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
-    "ember-cli-htmlbars": "1.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.0",
-    "ember-cli-release": "0.2.3",
+    "ember-cli-release": "0.2.6",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.6"
+    "ember-resolver": "^2.0.3",
+    "ember-try": "0.0.8"
   },
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import config from '../../config/environment';
 
 var resolver = Resolver.create();


### PR DESCRIPTION
I left Ember on 1.13.9 because I wasn't sure if the package was ready for 2.0 yet...