### PR TITLE
Add the repo url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/RavelLaw/e3",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Why:

* When visiting the addon on NPM it would be great to have a link to the
  repository.

This PR:

* Adds the repository url to package.json